### PR TITLE
fix "int' + 'str' error, revert to what mosesdecoder does

### DIFF
--- a/sacremoses/truecase.py
+++ b/sacremoses/truecase.py
@@ -295,8 +295,8 @@ class MosesTruecaser(object):
             # If it's the start of sentence.
             if is_first_word and best_case:  # Truecase sentence start.
                 token = best_case
-            elif known_case:  # Don't change known tokens.
-                token = known_case if use_known else token
+            elif known_case and use_known:  # Don't change known tokens.
+                token = token
             elif (
                 best_case
             ):  # Truecase otherwise unknown tokens? Heh? From https://github.com/moses-smt/mosesdecoder/blob/master/scripts/recaser/truecase.perl#L66


### PR DESCRIPTION
old version will cause 'int' + ‘str' error and is not what mosesdecoder actually does.