### PR TITLE
Web and basic protected patterns by default

### DIFF
--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -293,6 +293,8 @@ class MosesTokenizer(object):
         # TODO: emojis especially the multi codepoints
     ]
 
+
+
     def __init__(self, lang="en", custom_nonbreaking_prefixes_file=None):
         # Initialize the object.
         super(MosesTokenizer, self).__init__()
@@ -447,6 +449,11 @@ class MosesTokenizer(object):
         # De-duplicate spaces and clean ASCII junk
         for regexp, substitution in [self.DEDUPLICATE_SPACE, self.ASCII_JUNK]:
             text = re.sub(regexp, substitution, text)
+
+        if not protected_patterns:
+            # default protected patterns to avoid URLs and emails tokenization issues by default
+            protected_patterns = self.WEB_PROTECTED_PATTERNS
+            protected_patterns.extend(self.BASIC_PROTECTED_PATTERNS)
 
         if protected_patterns:
             # Find the tokens that needs to be protected.
@@ -825,3 +832,4 @@ class MosesDetokenizer(object):
 
 
 __all__ = ["MosesTokenizer", "MosesDetokenizer"]
+


### PR DESCRIPTION
By default the library is not using protected patterns such of `WEB_PROTECTED_PATTERNS` which contains for example URLs and emails patterns.
```python
# Example
tokenizer.tokenize("http://www.someurl.com")

# Expected output
["http://www.someurl.com"]

# sacremoses output
["http", ":",  "/", "/", "www.someurl.com"]

```
I suggest to use `WEB_PROTECTED_PATTERNS` and `BASIC_PATTERNS` by default when user does not specify protected patterns. 
This allow user to avoid issues with URLs tokenization when use `tokenize` function with default arguments. The user can still specify different protected patterns or force to don't use protected patterns by setting `protected_patterns` parameter to empty list:
```python
tokenizer.tokenize("http://www.someurl.com",protected_patterns=[])
```