### PR TITLE
Optimise `is_cjk(character)`

### DIFF
--- a/sacremoses/util.py
+++ b/sacremoses/util.py
@@ -91,6 +91,9 @@ class CJKChars(object):
     ]
 
 
+_CJKChars_ranges = CJKChars().ranges
+
+
 def is_cjk(character):
     """
     This checks for CJK character.
@@ -106,24 +109,11 @@ def is_cjk(character):
     :type character: char
     :return: bool
     """
-    return any(
-        [
-            start <= ord(character) <= end
-            for start, end in [
-                (4352, 4607),
-                (11904, 42191),
-                (43072, 43135),
-                (44032, 55215),
-                (63744, 64255),
-                (65072, 65103),
-                (65381, 65500),
-                (94208, 101119),
-                (110592, 110895),
-                (110960, 111359),
-                (131072, 196607),
-            ]
-        ]
-    )
+    char = ord(character)
+    for start, end in _CJKChars_ranges:
+        if char < end:
+            return char > start
+    return False
 
 
 def xml_escape(text):


### PR DESCRIPTION
The call to `ord()` and the list comprehension both showed up in my profiler.

Some observations:
- The call to `ord()` doesn't need to happen every iteration of that list comprehension.
- A list isn't necessary, we can stop searching once we've found a hit.
- The list is sorted, so we can be sure that if a char is lower than the upper bound of a group, we don't need to evaluate any of the higher ranges.
- Technically we could also do a binary search instead of a linear one, but I'm assuming that, overall, most chars will be in the lowest ranges (ascii) and the loop will abort on its first iteration.

Command:
```bash
time cat ../empty-trainer/contrib/test-data/clean.zhen.10k | cut -f1 | sacremoses -l zh detokenize > /dev/null

time cat ../empty-trainer/contrib/test-data/clean.zhen.10k | cut -f2 | sacremoses -l en detokenize > /dev/null
```

| Branch | detokenize zh | detokenize en |
| --- | --- | --- |
| This | 3.76 | 8.19 |
| Main | 5.67 |  8.90 |

| lang | lines | tokens |   bytes |
| ---- | ----- | ------ | ------- |
| zh   | 10000 | 484000 | 2619000 |
| en   | 10000 | 276000 | 1892000 |

cProfile output (sorted by top 'self' ascending):

Left: main &nbsp;&nbsp;&nbsp;&nbsp;  Right: this branch

<img width="767" alt="image" src="https://github.com/hplt-project/sacremoses/assets/198639/1448f84c-96c4-439b-83a5-57a45d2763c7">
